### PR TITLE
Pulse: fix NPE when navbar is hidden

### DIFF
--- a/src/com/android/systemui/navigation/pulse/FadingBlockRenderer.java
+++ b/src/com/android/systemui/navigation/pulse/FadingBlockRenderer.java
@@ -124,8 +124,10 @@ public class FadingBlockRenderer extends Renderer {
                 }
             }
         }
-        mCanvas.drawLines(mFFTPoints, mPaint);
-        mCanvas.drawPaint(mFadePaint);
+        if (mCanvas != null) {
+                mCanvas.drawLines(mFFTPoints, mPaint);
+                mCanvas.drawPaint(mFadePaint);
+        }
         postInvalidate();
     }
 


### PR DESCRIPTION
msg: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.graphics.Canvas.drawLines(float[], android.graphics.Paint)' on a null object reference
stacktrace: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.graphics.Canvas.drawLines(float[], android.graphics.Paint)' on a null object reference
	at com.android.systemui.navigation.pulse.FadingBlockRenderer.onFFTUpdate(FadingBlockRenderer.java:127)
	at com.android.systemui.navigation.pulse.PulseControllerImpl$2.onFFTUpdate(PulseControllerImpl.java:163)
	...

Signed-off-by: Chenyang Zhong <zhongcy95@gmail.com>